### PR TITLE
update --help output

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -67,6 +67,24 @@ kubectl multi get services -o wide`,
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch for changes to the requested object(s)")
 	cmd.Flags().BoolVar(&watchOnly, "watch-only", false, "watch for changes to the requested object(s), without listing/getting first")
 
+	// Set custom help template to match desired format
+	cmd.SetHelpTemplate(`{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if .HasExample}}Examples:
+{{.Example}}{{end}}
+
+{{if .HasAvailableFlags}}Options:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
+
+{{if .HasAvailableSubCommands}}Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+
+{{if .HasHelpSubCommands}}Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}
+
+{{if .HasAvailableSubCommands}}Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
+
 	return cmd
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -12,6 +12,19 @@ var (
 	allNamespaces bool
 )
 
+const helpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if .Example}}Examples:
+{{.Example}}
+
+{{end}}{{if .HasAvailableFlags}}Options:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+
+{{end}}Usage:
+  {{.UseLine}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}
+`
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "kubectl-multi",
@@ -46,6 +59,7 @@ kubectl multi delete deployment nginx`,
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() error {
+	rootCmd.SetHelpTemplate(helpTemplate)
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
Minor modification, make the "multi" plugin's --help output follow this order:
1. command Description, 
2. Examples, 
3. Options, 
4. Usage;
which is "kubectl" style.