### PR TITLE
Fixes #7 and #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ Thumbs.db
 # Kubernetes config (keep examples but not real configs)
 kubeconfig
 *.kubeconfig 
+
+# Local AI prompt files
+.cursor_prompts/
+
+# Local dev notes
+.dev_notes/

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -3,8 +3,45 @@ package cmd
 import (
 	"fmt"
 
+	"kubectl-multi/pkg/util"
+
 	"github.com/spf13/cobra"
 )
+
+// Custom help function for apply command
+func applyHelpFunc(cmd *cobra.Command, args []string) {
+	// Get original kubectl help
+	kubectlHelp, err := util.GetKubectlHelp("apply")
+	if err != nil {
+		// Fallback to default help if kubectl help is not available
+		cmd.Help()
+		return
+	}
+
+	// Multi-cluster plugin information
+	multiClusterInfo := `Apply a configuration to resources across all managed clusters.
+This command applies manifests to all KubeStellar managed clusters.`
+
+	// Multi-cluster examples
+	multiClusterExamples := `# Apply a deployment to all managed clusters
+kubectl multi apply -f deployment.yaml
+
+# Apply resources from a directory to all clusters
+kubectl multi apply -k dir/
+
+# Apply with dry-run to see what would be applied
+kubectl multi apply -f deployment.yaml --dry-run=client
+
+# Apply resources recursively from a directory
+kubectl multi apply -f dir/ -R`
+
+	// Multi-cluster usage
+	multiClusterUsage := `kubectl multi apply (-f FILENAME | -k DIRECTORY) [flags]`
+
+	// Format combined help
+	combinedHelp := util.FormatMultiClusterHelp(kubectlHelp, multiClusterInfo, multiClusterExamples, multiClusterUsage)
+	fmt.Fprintln(cmd.OutOrStdout(), combinedHelp)
+}
 
 func newApplyCommand() *cobra.Command {
 	var filename string
@@ -25,6 +62,9 @@ This command applies manifests to all KubeStellar managed clusters.`,
 	cmd.Flags().StringVarP(&filename, "filename", "f", "", "filename, directory, or URL to files to use to apply the resource")
 	cmd.Flags().BoolVarP(&recursive, "recursive", "R", false, "process the directory used in -f, --filename recursively")
 	cmd.Flags().StringVar(&dryRun, "dry-run", "none", "must be \"none\", \"server\", or \"client\"")
+
+	// Set custom help function
+	cmd.SetHelpFunc(applyHelpFunc)
 
 	return cmd
 }

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -3,8 +3,48 @@ package cmd
 import (
 	"fmt"
 
+	"kubectl-multi/pkg/util"
+
 	"github.com/spf13/cobra"
 )
+
+// Custom help function for delete command
+func deleteHelpFunc(cmd *cobra.Command, args []string) {
+	// Get original kubectl help
+	kubectlHelp, err := util.GetKubectlHelp("delete")
+	if err != nil {
+		// Fallback to default help if kubectl help is not available
+		cmd.Help()
+		return
+	}
+
+	// Multi-cluster plugin information
+	multiClusterInfo := `Delete resources across all managed clusters.
+This command deletes resources from all KubeStellar managed clusters.`
+
+	// Multi-cluster examples
+	multiClusterExamples := `# Delete a deployment from all managed clusters
+kubectl multi delete deployment nginx
+
+# Delete pods with a specific label from all clusters
+kubectl multi delete pods -l app=nginx
+
+# Delete resources from a file across all clusters
+kubectl multi delete -f deployment.yaml
+
+# Delete all pods in all clusters
+kubectl multi delete pods --all
+
+# Delete with force flag across all clusters
+kubectl multi delete pod nginx --force`
+
+	// Multi-cluster usage
+	multiClusterUsage := `kubectl multi delete [TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...] [flags]`
+
+	// Format combined help
+	combinedHelp := util.FormatMultiClusterHelp(kubectlHelp, multiClusterInfo, multiClusterExamples, multiClusterUsage)
+	fmt.Fprintln(cmd.OutOrStdout(), combinedHelp)
+}
 
 func newDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -14,6 +54,10 @@ func newDeleteCommand() *cobra.Command {
 			return fmt.Errorf("delete command not yet implemented")
 		},
 	}
+
+	// Set custom help function
+	cmd.SetHelpFunc(deleteHelpFunc)
+
 	return cmd
 }
 

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -6,7 +6,44 @@ import (
 	"github.com/spf13/cobra"
 
 	"kubectl-multi/pkg/cluster"
+	"kubectl-multi/pkg/util"
 )
+
+// Custom help function for describe command
+func describeHelpFunc(cmd *cobra.Command, args []string) {
+	// Get original kubectl help
+	kubectlHelp, err := util.GetKubectlHelp("describe")
+	if err != nil {
+		// Fallback to default help if kubectl help is not available
+		cmd.Help()
+		return
+	}
+
+	// Multi-cluster plugin information
+	multiClusterInfo := `Show details of a specific resource or group of resources across all managed clusters.
+This command displays detailed information about resources similar to kubectl describe,
+but across all KubeStellar managed clusters.`
+
+	// Multi-cluster examples
+	multiClusterExamples := `# Describe a specific pod across all clusters
+kubectl multi describe pod nginx
+
+# Describe all pods with a specific label across all clusters
+kubectl multi describe pods -l app=nginx
+
+# Describe a service across all clusters
+kubectl multi describe service/my-service
+
+# Describe nodes across all clusters
+kubectl multi describe nodes`
+
+	// Multi-cluster usage
+	multiClusterUsage := `kubectl multi describe [TYPE[.VERSION][.GROUP] [NAME_PREFIX | -l label] | TYPE[.VERSION][.GROUP]/NAME] [flags]`
+
+	// Format combined help
+	combinedHelp := util.FormatMultiClusterHelp(kubectlHelp, multiClusterInfo, multiClusterExamples, multiClusterUsage)
+	fmt.Fprintln(cmd.OutOrStdout(), combinedHelp)
+}
 
 func newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -35,6 +72,9 @@ kubectl multi describe nodes`,
 			return handleDescribeCommand(args, kubeconfig, remoteCtx, namespace, allNamespaces)
 		},
 	}
+
+	// Set custom help function
+	cmd.SetHelpFunc(describeHelpFunc)
 
 	return cmd
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -256,19 +256,19 @@ func handlePodsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourc
 			if allNamespaces {
 				if showLabels {
 					labels := util.FormatLabels(pod.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
 						clusterInfo.Name, pod.Namespace, pod.Name, ready, status, restarts, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
 						clusterInfo.Name, pod.Namespace, pod.Name, ready, status, restarts, age)
 				}
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(pod.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
 						clusterInfo.Name, pod.Name, ready, status, restarts, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
 						clusterInfo.Name, pod.Name, ready, status, restarts, age)
 				}
 			}
@@ -325,19 +325,19 @@ func handleServicesGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, res
 			if allNamespaces {
 				if showLabels {
 					labels := util.FormatLabels(svc.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Namespace, svc.Name, svcType, clusterIP, externalIP, ports, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Namespace, svc.Name, svcType, clusterIP, externalIP, ports, age)
 				}
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(svc.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Name, svcType, clusterIP, externalIP, ports, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Name, svcType, clusterIP, externalIP, ports, age)
 				}
 			}
@@ -452,7 +452,7 @@ func handleNamespacesGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, r
 				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
 					clusterInfo.Name, ns.Name, status, age, labels)
 			} else {
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
 					clusterInfo.Name, ns.Name, status, age)
 			}
 		}
@@ -633,7 +633,7 @@ func handlePVGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourceN
 				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 					clusterInfo.Name, pv.Name, capacity, accessModes, reclaimPolicy, status, claim, storageClass, reason, age, labels)
 			} else {
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 					clusterInfo.Name, pv.Name, capacity, accessModes, reclaimPolicy, status, claim, storageClass, reason, age)
 			}
 		}

--- a/pkg/util/kubectl_help.go
+++ b/pkg/util/kubectl_help.go
@@ -1,0 +1,250 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GetKubectlHelp retrieves the original kubectl help output for a given command
+func GetKubectlHelp(command string) (string, error) {
+	// Construct the kubectl command
+	args := []string{command, "--help"}
+
+	// Execute kubectl command
+	cmd := exec.Command("kubectl", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		// If kubectl is not found or fails, return a fallback message
+		return fmt.Sprintf("Original kubectl %s help not available: %v", command, err), nil
+	}
+
+	// Return the help output
+	helpOutput := stdout.String()
+	if helpOutput == "" {
+		helpOutput = stderr.String()
+	}
+
+	return strings.TrimSpace(helpOutput), nil
+}
+
+// GetKubectlRootHelp retrieves the original kubectl root help output
+func GetKubectlRootHelp() (string, error) {
+	// Execute kubectl command
+	cmd := exec.Command("kubectl", "--help")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		// If kubectl is not found or fails, return a fallback message
+		return fmt.Sprintf("Original kubectl help not available: %v", err), nil
+	}
+
+	// Return the help output
+	helpOutput := stdout.String()
+	if helpOutput == "" {
+		helpOutput = stderr.String()
+	}
+
+	return strings.TrimSpace(helpOutput), nil
+}
+
+// FormatMultiClusterHelp combines the original kubectl help with multi-cluster plugin information
+func FormatMultiClusterHelp(originalHelp, multiClusterInfo, multiClusterExamples, multiClusterUsage string) string {
+	if originalHelp == "" {
+		return multiClusterInfo
+	}
+
+	// Split the original help into sections
+	sections := splitHelpSections(originalHelp)
+
+	// Build the combined help output
+	var result strings.Builder
+
+	// Add multi-cluster information at the top
+	if multiClusterInfo != "" {
+		result.WriteString(multiClusterInfo)
+		result.WriteString("\n\n")
+	}
+
+	// Add original kubectl help sections in order: Description, Examples, Options, Usage
+	if sections["description"] != "" {
+		result.WriteString("Original kubectl description:\n")
+		result.WriteString(sections["description"])
+		result.WriteString("\n\n")
+	}
+
+	// Add kubectl-multi examples first, then original kubectl examples
+	if multiClusterExamples != "" {
+		result.WriteString("Examples:\n")
+		result.WriteString(multiClusterExamples)
+		result.WriteString("\n\n")
+	}
+
+	if sections["examples"] != "" {
+		result.WriteString("Original kubectl examples:\n")
+		result.WriteString(sections["examples"])
+		result.WriteString("\n\n")
+	}
+
+	if sections["options"] != "" {
+		result.WriteString("Options:\n")
+		// Mark flags that may not be implemented yet
+		markedOptions := markUnimplementedFlags(sections["options"])
+		result.WriteString(markedOptions)
+		result.WriteString("\n\n")
+	}
+
+	// Add kubectl-multi usage first, then original kubectl usage
+	if multiClusterUsage != "" {
+		result.WriteString("Usage:\n")
+		result.WriteString(multiClusterUsage)
+		result.WriteString("\n\n")
+	}
+
+	if sections["usage"] != "" {
+		result.WriteString("Original kubectl usage:\n")
+		result.WriteString(sections["usage"])
+		result.WriteString("\n\n")
+	}
+
+	return strings.TrimSpace(result.String())
+}
+
+// FormatMultiClusterRootHelp formats the root command help
+func FormatMultiClusterRootHelp(originalHelp, multiClusterInfo, multiClusterExamples, multiClusterUsage string) string {
+	if originalHelp == "" {
+		return multiClusterInfo
+	}
+
+	// Split the original help into sections
+	sections := splitHelpSections(originalHelp)
+
+	// Build the combined help output
+	var result strings.Builder
+
+	// Add multi-cluster information at the top
+	if multiClusterInfo != "" {
+		result.WriteString(multiClusterInfo)
+		result.WriteString("\n\n")
+	}
+
+	// Add original kubectl help sections in order: Description, Examples, Options, Usage
+	if sections["description"] != "" {
+		result.WriteString("Original kubectl description:\n")
+		result.WriteString(sections["description"])
+		result.WriteString("\n\n")
+	}
+
+	// Add kubectl-multi examples first, then original kubectl examples
+	if multiClusterExamples != "" {
+		result.WriteString("Examples:\n")
+		result.WriteString(multiClusterExamples)
+		result.WriteString("\n\n")
+	}
+
+	if sections["examples"] != "" {
+		result.WriteString("Original kubectl examples:\n")
+		result.WriteString(sections["examples"])
+		result.WriteString("\n\n")
+	}
+
+	if sections["options"] != "" {
+		result.WriteString("Options:\n")
+		// Mark flags that may not be implemented yet
+		markedOptions := markUnimplementedFlags(sections["options"])
+		result.WriteString(markedOptions)
+		result.WriteString("\n\n")
+	}
+
+	// Add kubectl-multi usage first, then original kubectl usage
+	if multiClusterUsage != "" {
+		result.WriteString("Usage:\n")
+		result.WriteString(multiClusterUsage)
+		result.WriteString("\n\n")
+	}
+
+	if sections["usage"] != "" {
+		result.WriteString("Original kubectl usage:\n")
+		result.WriteString(sections["usage"])
+		result.WriteString("\n\n")
+	}
+
+	return strings.TrimSpace(result.String())
+}
+
+// markUnimplementedFlags adds a note about flags that may not be implemented yet
+func markUnimplementedFlags(options string) string {
+	// Add a note at the beginning about flag forwarding
+	note := "Note: Some flags may not be fully implemented in multi-cluster mode yet.\n\n"
+	return note + options
+}
+
+// splitHelpSections parses the kubectl help output into sections
+func splitHelpSections(helpOutput string) map[string]string {
+	sections := make(map[string]string)
+	lines := strings.Split(helpOutput, "\n")
+
+	var currentSection string
+	var currentContent strings.Builder
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+
+		// Detect section headers
+		if strings.HasPrefix(trimmedLine, "Examples:") {
+			if currentSection != "" {
+				// Don't trim the content to preserve indentation
+				sections[currentSection] = currentContent.String()
+			}
+			currentSection = "examples"
+			currentContent.Reset()
+			continue
+		}
+
+		if strings.HasPrefix(trimmedLine, "Options:") {
+			if currentSection != "" {
+				// Don't trim the content to preserve indentation
+				sections[currentSection] = currentContent.String()
+			}
+			currentSection = "options"
+			currentContent.Reset()
+			continue
+		}
+
+		if strings.HasPrefix(trimmedLine, "Usage:") {
+			if currentSection != "" {
+				// Don't trim the content to preserve indentation
+				sections[currentSection] = currentContent.String()
+			}
+			currentSection = "usage"
+			currentContent.Reset()
+			continue
+		}
+
+		// If we haven't found a section header yet, this is the description
+		if currentSection == "" && trimmedLine != "" {
+			currentSection = "description"
+		}
+
+		if currentSection != "" {
+			currentContent.WriteString(line)
+			currentContent.WriteString("\n")
+		}
+	}
+
+	// Add the last section
+	if currentSection != "" {
+		// Don't trim the content to preserve indentation
+		sections[currentSection] = currentContent.String()
+	}
+
+	return sections
+}


### PR DESCRIPTION
## Fixes #7 
### What Changed
- **Help Integration**: `get, describe, apply, delete, etc.` now include original kubectl help output
- **Sections Separater**: Added `Original kubectl <section_name>:` headers for better distinction
- **Multi-cluster Examples**: Added kubectl-multi examples before original kubectl examples
- Added warning about unimplemented flags in multi-cluster mode

### Commands Examples
- `kubectl-multi get --help`
- `kubectl-multi describe --help` 
- `kubectl-multi apply --help`
- `kubectl-multi delete --help`
- `kubectl-multi --help` (root command)

## Fixes #10 
Fixed format specifier mismatches in:
- `handleNamespacesGet`: Removed extra `%s` specifier when `showLabels` is false
- `handlePodsGet`: Corrected format strings to match argument count
- `handleServicesGet`: Fixed format specifier count to match arguments
- `handlePVGet`: Removed extra `%s` specifier when `showLabels` is false