### PR TITLE
Fixed --show-labels for get 

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -224,19 +224,19 @@ func handlePodsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourc
 			if allNamespaces {
 				if showLabels {
 					labels := util.FormatLabels(pod.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
 						clusterInfo.Name, pod.Namespace, pod.Name, ready, status, restarts, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
 						clusterInfo.Name, pod.Namespace, pod.Name, ready, status, restarts, age)
 				}
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(pod.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
 						clusterInfo.Name, pod.Name, ready, status, restarts, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
 						clusterInfo.Name, pod.Name, ready, status, restarts, age)
 				}
 			}
@@ -293,19 +293,19 @@ func handleServicesGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, res
 			if allNamespaces {
 				if showLabels {
 					labels := util.FormatLabels(svc.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Namespace, svc.Name, svcType, clusterIP, externalIP, ports, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Namespace, svc.Name, svcType, clusterIP, externalIP, ports, age)
 				}
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(svc.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Name, svcType, clusterIP, externalIP, ports, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, svc.Name, svcType, clusterIP, externalIP, ports, age)
 				}
 			}


### PR DESCRIPTION
No longer returns MISSING error handling fallback for labels column in default output associated with get. 
Now labels are only shown when `kubectl multi get nodes --show-labels` is ran instead of `kubectl multi get nodes` similar to how `kubectl get nodes --show-labels` vs `kubectl multi get nodes` works