### PR TITLE
added the kubectl multi get all -A

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -142,6 +142,8 @@ func handleGetCommand(args []string, outputFormat, selector string, showLabels, 
 
 	// Handle different resource types
 	switch strings.ToLower(resourceType) {
+	case "all":
+		return handleAllGet(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
 	case "nodes", "node", "no":
 		return handleNodesGet(tw, clusters, resourceName, selector, showLabels, outputFormat)
 	case "pods", "pod", "po":
@@ -165,6 +167,29 @@ func handleGetCommand(args []string, outputFormat, selector string, showLabels, 
 	}
 }
 
+func handleAllGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourceName, selector string, showLabels bool, outputFormat, namespace string, allNamespaces bool) error {
+	fmt.Println("==> Pods")
+	if err := handlePodsGet(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces); err != nil {
+		return err
+	}
+	tw.Flush()
+
+	fmt.Println("\n==> Services")
+	tw = tabwriter.NewWriter(util.GetOutputStream(), 0, 0, 2, ' ', 0)
+	if err := handleServicesGet(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces); err != nil {
+		return err
+	}
+	tw.Flush()
+
+	fmt.Println("\n==> Deployments")
+	tw = tabwriter.NewWriter(util.GetOutputStream(), 0, 0, 2, ' ', 0)
+	if err := handleDeploymentsGet(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces); err != nil {
+		return err
+	}
+	tw.Flush()
+
+	return nil
+}
 func handleNodesGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourceName, selector string, showLabels bool, outputFormat string) error {
 	// Print header only once at the top
 	if showLabels {


### PR DESCRIPTION
previous: 

```
./bin/kubectl-multi get all -A
Warning: failed to list all in cluster cluster1: the server could not find the requested resource
Warning: failed to list all in cluster cluster2: the server could not find the requested resource
Warning: failed to list all in cluster its1-cluster: the server could not find the requested resource
CLUSTER  NAMESPACE  NAME  AGE
```
now:
 ```
make build 
Building kubectl-multi...
go build -o bin/kubectl-multi main.go
Binary built: bin/kubectl-multi
rupam@rupam-1-0:~/lfx/kubectl-plugin$ ./bin/kubectl-multi get all -A
==> Pods
CLUSTER       NAMESPACE                            NAME                                                       READY  STATUS   RESTARTS  AGE
cluster1      kube-system                          coredns-76f75df574-hvghk                                   1/1    Running  0         46m
cluster1      kube-system                          coredns-76f75df574-xgv82                                   1/1    Running  0         46m
cluster1      kube-system                          etcd-cluster1-control-plane                                1/1    Running  0         46m
cluster1      kube-system                          kindnet-8jf4g                                              1/1    Running  0         46m
cluster1      kube-system                          kube-apiserver-cluster1-control-plane                      1/1    Running  0         46m
cluster1      kube-system                          kube-controller-manager-cluster1-control-plane             1/1    Running  0         46m
cluster1      kube-system                          kube-proxy-7fjpj                                           1/1    Running  0         46m
cluster1      kube-system                          kube-scheduler-cluster1-control-plane                      1/1    Running  0         46m
cluster1      local-path-storage                   local-path-provisioner-7577fdbbfb-qzr79                    1/1    Running  0         46m
cluster1      open-cluster-management-agent-addon  status-agent-6c7d85bcc-7gfc9                               1/1    Running  0         36m
cluster1      open-cluster-management-agent        klusterlet-agent-6c94bbd65d-7nndf                          1/1    Running  0         36m
cluster1      open-cluster-management              klusterlet-76576d97bb-5t9tl                                1/1    Running  0         36m
cluster1      open-cluster-management              klusterlet-76576d97bb-8t6pv                                1/1    Running  0         36m
cluster1      open-cluster-management              klusterlet-76576d97bb-qg7qq                                1/1    Running  0         37m
cluster2      kube-system                          coredns-76f75df574-lwntn                                   1/1    Running  0         46m
cluster2      kube-system                          coredns-76f75df574-mhph4                                   1/1    Running  0         46m
cluster2      kube-system                          etcd-cluster2-control-plane                                1/1    Running  0         46m
cluster2      kube-system                          kindnet-j7pb4                                              1/1    Running  0         46m
cluster2      kube-system                          kube-apiserver-cluster2-control-plane                      1/1    Running  0         46m
cluster2      kube-system                          kube-controller-manager-cluster2-control-plane             1/1    Running  0         46m
cluster2      kube-system                          kube-proxy-9zqsn                                           1/1    Running  0         46m
cluster2      kube-system                          kube-scheduler-cluster2-control-plane                      1/1    Running  0         46m
cluster2      local-path-storage                   local-path-provisioner-7577fdbbfb-gx25s                    1/1    Running  0         46m
cluster2      open-cluster-management-agent-addon  status-agent-776fc4d8c6-tlvpm                              1/1    Running  0         36m
cluster2      open-cluster-management-agent        klusterlet-agent-74fddc7b8d-9g4fm                          1/1    Running  0         36m
cluster2      open-cluster-management              klusterlet-76576d97bb-4vw98                                1/1    Running  0         36m
cluster2      open-cluster-management              klusterlet-76576d97bb-6wzz2                                1/1    Running  0         37m
cluster2      open-cluster-management              klusterlet-76576d97bb-gt6v2                                1/1    Running  0         36m
its1-cluster  kube-system                          coredns-68559449b6-zz69w                                   1/1    Running  0         40m
its1-cluster  open-cluster-management              cluster-manager-568d449f4d-pxmt7                           1/1    Running  0         38m
its1-cluster  open-cluster-management              cluster-manager-568d449f4d-27ddv                           1/1    Running  0         38m
its1-cluster  open-cluster-management              cluster-manager-568d449f4d-fsdqm                           1/1    Running  0         38m
its1-cluster  open-cluster-management-hub          cluster-manager-work-webhook-64b9959b54-ptck7              1/1    Running  0         38m
its1-cluster  open-cluster-management-hub          cluster-manager-addon-manager-controller-6b6d468dcb-2c6ng  1/1    Running  0         38m
its1-cluster  open-cluster-management-hub          cluster-manager-registration-controller-568b9654c7-gfvqs   1/1    Running  0         38m
its1-cluster  open-cluster-management-hub          cluster-manager-registration-webhook-8559cc7947-8tc4j      1/1    Running  0         38m
its1-cluster  open-cluster-management-hub          cluster-manager-placement-controller-5ffc6c8954-gwcp8      1/1    Running  0         38m
its1-cluster  open-cluster-management              addon-status-controller-57496b8545-4t2mz                   1/1    Running  0         38m

==> Services
CLUSTER       NAMESPACE                    NAME                                  TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)                 AGE
cluster1      default                      kubernetes                            ClusterIP  10.96.0.1      <none>       443/TCP                 46m
cluster1      kube-system                  kube-dns                              ClusterIP  10.96.0.10     <none>       53/UDP,53/TCP,9153/TCP  46m
cluster2      default                      kubernetes                            ClusterIP  10.96.0.1      <none>       443/TCP                 46m
cluster2      kube-system                  kube-dns                              ClusterIP  10.96.0.10     <none>       53/UDP,53/TCP,9153/TCP  46m
its1-cluster  default                      kubernetes                            ClusterIP  10.96.137.46   <none>       443/TCP                 40m
its1-cluster  kube-system                  kube-dns                              ClusterIP  10.96.53.138   <none>       53/UDP,53/TCP,9153/TCP  40m
its1-cluster  open-cluster-management-hub  cluster-manager-registration-webhook  ClusterIP  10.96.136.232  <none>       9443/TCP                38m
its1-cluster  open-cluster-management-hub  cluster-manager-work-webhook          ClusterIP  10.96.220.18   <none>       9443/TCP                38m

==> Deployments
CLUSTER       NAMESPACE                            NAME                                      READY  UP-TO-DATE  AVAILABLE  AGE
cluster1      kube-system                          coredns                                   2/2    2           2          46m  %!s(MISSING)
cluster1      local-path-storage                   local-path-provisioner                    1/1    1           1          46m  %!s(MISSING)
cluster1      open-cluster-management-agent-addon  status-agent                              1/1    1           1          36m  %!s(MISSING)
cluster1      open-cluster-management-agent        klusterlet-agent                          1/1    1           1          36m  %!s(MISSING)
cluster1      open-cluster-management              klusterlet                                3/3    3           3          37m  %!s(MISSING)
cluster2      kube-system                          coredns                                   2/2    2           2          46m  %!s(MISSING)
cluster2      local-path-storage                   local-path-provisioner                    1/1    1           1          46m  %!s(MISSING)
cluster2      open-cluster-management-agent-addon  status-agent                              1/1    1           1          36m  %!s(MISSING)
cluster2      open-cluster-management-agent        klusterlet-agent                          1/1    1           1          36m  %!s(MISSING)
cluster2      open-cluster-management              klusterlet                                3/3    3           3          37m  %!s(MISSING)
its1-cluster  kube-system                          coredns                                   1/1    1           1          40m  %!s(MISSING)
its1-cluster  open-cluster-management-hub          cluster-manager-work-webhook              1/1    1           1          38m  %!s(MISSING)
its1-cluster  open-cluster-management              cluster-manager                           3/3    3           3          38m  %!s(MISSING)
its1-cluster  open-cluster-management-hub          cluster-manager-addon-manager-controller  1/1    1           1          38m  %!s(MISSING)
its1-cluster  open-cluster-management-hub          cluster-manager-registration-controller   1/1    1           1          38m  %!s(MISSING)
its1-cluster  open-cluster-management-hub          cluster-manager-registration-webhook      1/1    1           1          38m  %!s(MISSING)
its1-cluster  open-cluster-management-hub          cluster-manager-placement-controller      1/1    1           1          38m  %!s(MISSING)
its1-cluster  open-cluster-management              addon-status-controller                   1/1    1           1          38m  %!s(MISSING)
rupam@rupam-1-0:~/lfx/kubectl-plugin$ 

```