### PR TITLE
change the output format to fix items in columns for configmaps 

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -576,6 +576,7 @@ func handleNamespacesGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, r
 	}
 	return nil
 }
+
 func handleConfigMapsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourceName, selector string, showLabels bool, outputFormat, namespace string, allNamespaces bool) error {
 	// Print header only once at the top
 	if allNamespaces {

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -576,7 +576,6 @@ func handleNamespacesGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, r
 	}
 	return nil
 }
-
 func handleConfigMapsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resourceName, selector string, showLabels bool, outputFormat, namespace string, allNamespaces bool) error {
 	// Print header only once at the top
 	if allNamespaces {
@@ -631,10 +630,10 @@ func handleConfigMapsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, r
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(cm.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n",
 						clusterInfo.Name, cm.Name, dataCount, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n",
 						clusterInfo.Name, cm.Name, dataCount, age)
 				}
 			}


### PR DESCRIPTION
now :

```
 ./bin/kubectl-multi get cm
CLUSTER       NAME              DATA  AGE
cluster1      kube-root-ca.crt  1     10m
cluster2      kube-root-ca.crt  1     10m
its1-cluster  kube-root-ca.crt  1     5m4s
```

```
 kubectl create configmap test-config --from-literal=key1=value1 --from-literal=key2=value2
kubectl label configmap test-config app=myapp env=production tier=backend
configmap/test-config created
configmap/test-config labeled

rupam@rupam-1-0:~/lfx/kubectl-plugin$ ./bin/kubectl-multi get cm --show-labels
CLUSTER       NAME              DATA  AGE  LABELS
cluster1      kube-root-ca.crt  1     21m  <none>
cluster2      kube-root-ca.crt  1     20m  <none>
its1-cluster  kube-root-ca.crt  1     15m  <none>
its1-cluster  test-config       2     11s  app=myapp,env=production,tier=backend
```

fix #46 