### PR TITLE
 fixed the logs of deploy , pvc and secrets

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -514,19 +514,19 @@ func handleDeploymentsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, 
 			if allNamespaces {
 				if showLabels {
 					labels := util.FormatLabels(deploy.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, deploy.Namespace, deploy.Name, ready, upToDate, available, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, deploy.Namespace, deploy.Name, ready, upToDate, available, age)
 				}
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(deploy.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, deploy.Name, ready, upToDate, available, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, deploy.Name, ready, upToDate, available, age)
 				}
 			}
@@ -698,10 +698,10 @@ func handleSecretsGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, reso
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(secret.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\t%s\n",
 						clusterInfo.Name, secret.Name, secretType, dataCount, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
 						clusterInfo.Name, secret.Name, secretType, dataCount, age)
 				}
 			}
@@ -807,19 +807,19 @@ func handlePVCGet(tw *tabwriter.Writer, clusters []cluster.ClusterInfo, resource
 			if allNamespaces {
 				if showLabels {
 					labels := util.FormatLabels(pvc.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, pvc.Namespace, pvc.Name, status, volume, capacity, accessModes, storageClass, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, pvc.Namespace, pvc.Name, status, volume, capacity, accessModes, storageClass, age)
 				}
 			} else {
 				if showLabels {
 					labels := util.FormatLabels(pvc.Labels)
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, pvc.Name, status, volume, capacity, accessModes, storageClass, age, labels)
 				} else {
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						clusterInfo.Name, pvc.Name, status, volume, capacity, accessModes, storageClass, age)
 				}
 			}


### PR DESCRIPTION
fix #47 
fix #48  
fix #49 

```
rupam@rupam-1-0:~/lfx/kubectl-plugin$ ./bin/kubectl-multi get secrets -A
CLUSTER       NAMESPACE                            NAME                                            TYPE                            DATA  AGE
cluster1      kube-system                          bootstrap-token-abcdef                          bootstrap.kubernetes.io/token   6     40m
cluster1      open-cluster-management-agent-addon  addon-status-hub-kubeconfig                     Opaque                          3     29m
cluster1      open-cluster-management-agent-addon  open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     30m
cluster1      open-cluster-management-agent        bootstrap-hub-kubeconfig                        Opaque                          1     31m
cluster1      open-cluster-management-agent        hub-kubeconfig-secret                           Opaque                          5     30m
cluster1      open-cluster-management-agent        open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     30m
cluster1      open-cluster-management              open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     31m
cluster2      kube-system                          bootstrap-token-abcdef                          bootstrap.kubernetes.io/token   6     40m
cluster2      open-cluster-management-agent-addon  addon-status-hub-kubeconfig                     Opaque                          3     29m
cluster2      open-cluster-management-agent-addon  open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     30m
cluster2      open-cluster-management-agent        bootstrap-hub-kubeconfig                        Opaque                          1     31m
cluster2      open-cluster-management-agent        hub-kubeconfig-secret                           Opaque                          5     30m
cluster2      open-cluster-management-agent        open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     30m
cluster2      open-cluster-management              open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     31m
its1-cluster  kube-system                          vcluster-0.node-password.k3s                    Opaque                          1     35m
its1-cluster  kube-system                          k3s-serving                                     kubernetes.io/tls               2     35m
its1-cluster  open-cluster-management              open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     32m
its1-cluster  open-cluster-management-hub          signer-secret                                   kubernetes.io/tls               2     32m
its1-cluster  open-cluster-management-hub          registration-webhook-serving-cert               kubernetes.io/tls               2     32m
its1-cluster  open-cluster-management-hub          work-webhook-serving-cert                       kubernetes.io/tls               2     32m
its1-cluster  open-cluster-management-hub          open-cluster-management-image-pull-credentials  kubernetes.io/dockerconfigjson  1     32m
its1-cluster  open-cluster-management              sh.helm.release.v1.status-addon.v1              helm.sh/release.v1              1     32m

rupam@rupam-1-0:~/lfx/kubectl-plugin$ ./bin/kubectl-multi get pvc
CLUSTER       NAME      STATUS   VOLUME  CAPACITY  ACCESS MODES  STORAGE CLASS  AGE
its1-cluster  test-pvc  Pending          <unset>                 <none>         3m35s
rupam@rupam-1-0:~/lfx/kubectl-plugin$ ./bin/kubectl-multi get deploy -A
CLUSTER       NAMESPACE                            NAME                                      READY  UP-TO-DATE  AVAILABLE  AGE
cluster1      kube-system                          coredns                                   2/2    2           2          41m
cluster1      local-path-storage                   local-path-provisioner                    1/1    1           1          41m
cluster1      open-cluster-management-agent-addon  status-agent                              1/1    1           1          29m
cluster1      open-cluster-management-agent        klusterlet-agent                          1/1    1           1          31m
cluster1      open-cluster-management              klusterlet                                3/3    3           3          32m
cluster2      kube-system                          coredns                                   2/2    2           2          40m
cluster2      local-path-storage                   local-path-provisioner                    1/1    1           1          40m
cluster2      open-cluster-management-agent-addon  status-agent                              1/1    1           1          29m
cluster2      open-cluster-management-agent        klusterlet-agent                          1/1    1           1          30m
cluster2      open-cluster-management              klusterlet                                3/3    3           3          31m
its1-cluster  kube-system                          coredns                                   1/1    1           1          35m
its1-cluster  open-cluster-management              cluster-manager                           3/3    3           3          32m
its1-cluster  open-cluster-management-hub          cluster-manager-registration-webhook      1/1    1           1          32m
its1-cluster  open-cluster-management-hub          cluster-manager-registration-controller   1/1    1           1          32m
its1-cluster  open-cluster-management-hub          cluster-manager-placement-controller      1/1    1           1          32m
its1-cluster  open-cluster-management-hub          cluster-manager-addon-manager-controller  1/1    1           1          32m
its1-cluster  open-cluster-management-hub          cluster-manager-work-webhook              1/1    1           1          32m
its1-cluster  open-cluster-management              addon-status-controller                   1/1    1           1          32m
rupam@rupam-1-0:~/lfx/kubectl-plugin$ 
```