### PR TITLE
add support for  Kubernetes event in kubectl-multi get command

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -177,6 +177,8 @@ func handleGetCommand(args []string, outputFormat, selector string, showLabels, 
 		return handlePVGet(tw, clusters, resourceName, selector, showLabels, outputFormat)
 	case "persistentvolumeclaims", "persistentvolumeclaim", "pvc":
 		return handlePVCGet(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
+	case "events", "event", "ev":
+		return handleEventsGet(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
 	default:
 		return handleGenericGet(tw, clusters, resourceType, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
 	}


### PR DESCRIPTION
## Description
Add support for ReplicaSets, DaemonSets, StatefulSets, CronJobs, Ingress, NetworkPolicies, and ServiceAccounts to the kubectl-multi get command.

#37 
