### PR TITLE
feat: add support for Endpoints in kubectl-multi get

### DIFF
--- a/pkg/cmd/multiget.go
+++ b/pkg/cmd/multiget.go
@@ -379,8 +379,6 @@ func handleMultiGetCommand(args []string, outputFormat, selector string, showLab
 		return handleSecretsGetMulti(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
 	case "serviceaccounts", "serviceaccount", "sa":
 		return handleServiceAccountsGetMulti(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
-	case "endpoints", "endpoint", "ep":
-		return handleEndpointsGetMulti(tw, clusters, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
 	case "persistentvolumes", "persistentvolume", "pv":
 		return handlePVGetMulti(tw, clusters, resourceName, selector, showLabels, outputFormat)
 	case "persistentvolumeclaims", "persistentvolumeclaim", "pvc":
@@ -452,14 +450,6 @@ func handleServiceAccountsGetMulti(tw *tabwriter.Writer, clusters []MultiGetClus
 		infos = append(infos, toClusterInfo(c))
 	}
 	return handleServiceAccountsGet(tw, infos, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
-}
-
-func handleEndpointsGetMulti(tw *tabwriter.Writer, clusters []MultiGetClusterInfo, resourceName, selector string, showLabels bool, outputFormat, namespace string, allNamespaces bool) error {
-	var infos []cluster.ClusterInfo
-	for _, c := range clusters {
-		infos = append(infos, toClusterInfo(c))
-	}
-	return handleEndpointsGet(tw, infos, resourceName, selector, showLabels, outputFormat, namespace, allNamespaces)
 }
 
 func handlePVGetMulti(tw *tabwriter.Writer, clusters []MultiGetClusterInfo, resourceName, selector string, showLabels bool, outputFormat string) error {


### PR DESCRIPTION
## Summary
This PR adds support for the Endpoints API in kubectl-multi get.

- Adds handleEndpointsGet in get.go for single-cluster listing
- Adds handleEndpointsGetMulti in multiget.go for multi-cluster support
- Updates switch/case to call the new handlers
- Verified functionality with test Endpoints in a running cluster

#37
