### PR TITLE
Add automation for gitub release using goreleaser

### DIFF
--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -1,0 +1,31 @@
+
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "latest"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ kubeconfig
 
 # Local dev notes
 .dev_notes/
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,36 @@
+version: 2
+
+project_name: kubectl-plugin
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+  
+
+changelog:
+  use: github
+  sort: asc
+  format: "{{ .SHA }}: {{ .Message }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).


### PR DESCRIPTION
### Description

This PR adds automation for release. 

### Related Issue
Issue #77 

To make a release run:
```
git tag -a v0.0.1 -m "Gitub Release"  
git push origin v0.0.1  
```
Maintainer can use the version accordingly.
