### PR TITLE
change the name from plugin to multi

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 version: 2
 
-project_name: kubectl-plugin
+project_name: kubectl-multi
 
 builds:
   - env:


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
in the previous release the name of the binary was kubectl-plugin which is justified with the project name but the actual binary command name is kubectl-multi so change the binary name for release to multi . 

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
