### PR TITLE
feat: Add version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X kubectl-multi/pkg/util.Version={{.Version}}
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -83,8 +83,9 @@ const helpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "kubectl-multi",
-	Short: "Multi-cluster kubectl operations for KubeStellar",
+	Use:     "kubectl-multi",
+	Version: util.Version,
+	Short:   "Multi-cluster kubectl operations for KubeStellar",
 	Long: `kubectl-multi provides multi-cluster operations for KubeStellar managed clusters.
 It executes kubectl commands across all managed clusters and presents unified output.
 
@@ -150,6 +151,7 @@ func init() {
 	rootCmd.AddCommand(newTopCommand())
 	rootCmd.AddCommand(newRunCommand())
 	rootCmd.AddCommand(newMultiGetCommand()) // Register multiget
+	rootCmd.AddCommand(util.VersionCmd)
 
 	// Add the install command - NEW LINE
 	streams := genericclioptions.IOStreams{

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = "dev" // overridden by goreleaser during build process
+
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display the version of kubectl plugin",
+	Long:  `Shows the version information of the KubeStellar kubectl plugin.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("kubectl plugin %s\n", Version)
+	},
+}


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
This PR adds version command for kubectl-multi. User can get version info with any of the following commands:

1. ```kubectl multi -v```
2. ```kubectl multi --version```
3. ```kubectl multi version```


### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #84

## Output

```
❯ ./dist/kubectl-multi_darwin_arm64_v8.0/kubectl-multi -v
kubectl-multi version 0.1.0-test
```
