### PR TITLE
feat: Add deletion confirmation

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+	"bufio"
+	"os"
 
 	"kubectl-multi/pkg/cluster"
 	"kubectl-multi/pkg/util"
@@ -100,6 +103,21 @@ func handleDeleteCommand(args []string, filename string, recursive bool, dryRun,
 	}
 	if len(clusters) == 0 {
 		return fmt.Errorf("no clusters discovered")
+	}
+
+	fmt.Println("Are you sure you want to delete these resources ?")
+	fmt.Println("Type 'yes' to confirm, or anything else to cancel.")
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+
+	if err != nil {
+		return fmt.Errorf("failed to read confirmation: %v", err)
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response != "yes" {
+		fmt.Println("Deletion cancelled...")
+		return nil
 	}
 
 	// Find current context from kubeconfig


### PR DESCRIPTION
### Description

This PR asks for the confirmation before deleting any resources. 
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #107

### Screenshots or Logs (if applicable)

```
❯ ./bin/kubectl-multi delete -f deployment.yaml
Are you sure you want to delete these resources ?
Type 'yes' to confirm, or anything else to cancel.
no
Deletion cancelled...
❯ ./bin/kubectl-multi delete -f deployment.yaml
Are you sure you want to delete these resources ?
Type 'yes' to confirm, or anything else to cancel.
yes
=== Cluster: kind-democluster ===
deployment.apps "my-app" deleted from default namespace

=== Cluster: cluster1 ===
deployment.apps "my-app" deleted from default namespace

=== Cluster: cluster2 ===
deployment.apps "my-app" deleted from default namespace

```

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
