### PR TITLE
🐛 Fix docs-release workflow JSON payload

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+# No GITHUB_TOKEN permissions needed - uses WORKFLOW_SYNC_TOKEN secret
+permissions: {}
+
 jobs:
   trigger-docs:
     runs-on: ubuntu-latest
@@ -12,6 +15,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
         run: |
-          gh api repos/kubestellar/docs/dispatches \
-            -f event_type=create-version-branch \
-            -f client_payload="{\"project\":\"multi-plugin\",\"version\":\"${{ github.event.release.tag_name }}\",\"source_repo\":\"${{ github.repository }}\",\"source_branch\":\"${{ github.event.release.target_commitish }}\"}"
+          cat <<EOF | gh api repos/kubestellar/docs/dispatches --input -
+          {
+            "event_type": "create-version-branch",
+            "client_payload": {
+              "project": "multi-plugin",
+              "version": "${{ github.event.release.tag_name }}",
+              "source_repo": "${{ github.repository }}",
+              "source_branch": "${{ github.event.release.target_commitish }}"
+            }
+          }
+          EOF


### PR DESCRIPTION
## Summary
Fix the docs-release workflow to properly pass JSON payload to gh api.

The `-f client_payload="{...}"` syntax was passing the payload as a string instead of a JSON object, causing HTTP 422 errors:
```
For 'properties/client_payload', "{...}" is not an object.
```

## Changes
- Use heredoc with `--input -` to pass proper JSON body
- Added explicit `permissions: {}` for security

## Testing
Verified fix works in kubectl-claude v0.4.3 release automation.

🤖 Generated with Claude Code